### PR TITLE
Add support for quiet output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,43 +9,36 @@ scheduler.
 It supports Windows, Linux and macOS and runs on both python2 and python3.
 
 ## How to use
-
-- If you don’t already have it, download and install
+* If you don’t already have it, download and install
   [the latest python version](https://www.python.org/downloads/).
-- Download [the latest release](https://github.com/Chronial/snapraid-runner/releases)
+* Download [the latest release](https://github.com/Chronial/snapraid-runner/releases)
   of this script and extract it anywhere or clone this repository via git.
-- Copy/rename the `snapraid-runner.conf.example` to `snapraid-runner.conf` and
+* Copy/rename the `snapraid-runner.conf.example` to `snapraid-runner.conf` and
   edit its contents. You need to at least configure `snapraid.exectable` and
   `snapraid.config`.
-- Run the script via `python3 snapraid-runner.py` on Linux or
-  `py -3 snapraid-runner.py` on Windows.
+* Run the script via `python3 snapraid-runner.py` on Linux or
+ `py -3 snapraid-runner.py` on Windows.
 
 ## Features
-
-- Runs `diff` before `sync` to see how many files were deleted and aborts if
+* Runs `diff` before `sync` to see how many files were deleted and aborts if
   that number exceeds a set threshold.
-- Can create a size-limited rotated logfile.
-- Can send notification emails after each run or only for failures.
-- Can run `scrub` after `sync`
-- Optional quiet mode with `-q` to limit logging noise
+* Can create a size-limited rotated logfile.
+* Can send notification emails after each run or only for failures.
+* Can run `scrub` after `sync`
+* Optional quiet mode with `-q` to limit logging noise
 
 ## Changelog
-
 ### v0.4 (17 Aug 2019)
-
-- Add compatibility with python3 (by reed-jones)
-- Add support for running `snapraid touch` (by ShoGinn, PR-11)
-- Add SMTP TLS support
+* Add compatibility with python3 (by reed-jones)
+* Add support for running `snapraid touch` (by ShoGinn, PR-11)
+* Add SMTP TLS support
 
 ### v0.3 (20 Jul 2017)
-
-- Limit size of sent emails
+* Limit size of sent emails
 
 ### v0.2 (27 Apr 2015)
-
-- Fix compatibility with Snapraid 8.0
-- Allow disabling of scrub from command line
+* Fix compatibility with Snapraid 8.0
+* Allow disabling of scrub from command line
 
 ### v0.1 (16 Feb 2014)
-
-- Initial release
+* Initial release

--- a/README.md
+++ b/README.md
@@ -9,35 +9,43 @@ scheduler.
 It supports Windows, Linux and macOS and runs on both python2 and python3.
 
 ## How to use
-* If you don’t already have it, download and install
+
+- If you don’t already have it, download and install
   [the latest python version](https://www.python.org/downloads/).
-* Download [the latest release](https://github.com/Chronial/snapraid-runner/releases)
+- Download [the latest release](https://github.com/Chronial/snapraid-runner/releases)
   of this script and extract it anywhere or clone this repository via git.
-* Copy/rename the `snapraid-runner.conf.example` to `snapraid-runner.conf` and
+- Copy/rename the `snapraid-runner.conf.example` to `snapraid-runner.conf` and
   edit its contents. You need to at least configure `snapraid.exectable` and
   `snapraid.config`.
-* Run the script via `python3 snapraid-runner.py` on Linux or
- `py -3 snapraid-runner.py` on Windows.
+- Run the script via `python3 snapraid-runner.py` on Linux or
+  `py -3 snapraid-runner.py` on Windows.
 
 ## Features
-* Runs `diff` before `sync` to see how many files were deleted and aborts if
+
+- Runs `diff` before `sync` to see how many files were deleted and aborts if
   that number exceeds a set threshold.
-* Can create a size-limited rotated logfile.
-* Can send notification emails after each run or only for failures.
-* Can run `scrub` after `sync`
+- Can create a size-limited rotated logfile.
+- Can send notification emails after each run or only for failures.
+- Can run `scrub` after `sync`
+- Optional quiet mode with `-q` to limit logging noise
 
 ## Changelog
+
 ### v0.4 (17 Aug 2019)
-* Add compatibility with python3 (by reed-jones)
-* Add support for running `snapraid touch` (by ShoGinn, PR-11)
-* Add SMTP TLS support
+
+- Add compatibility with python3 (by reed-jones)
+- Add support for running `snapraid touch` (by ShoGinn, PR-11)
+- Add SMTP TLS support
 
 ### v0.3 (20 Jul 2017)
-* Limit size of sent emails
+
+- Limit size of sent emails
 
 ### v0.2 (27 Apr 2015)
-* Fix compatibility with Snapraid 8.0
-* Allow disabling of scrub from command line
+
+- Fix compatibility with Snapraid 8.0
+- Allow disabling of scrub from command line
 
 ### v0.1 (16 Feb 2014)
-* Initial release
+
+- Initial release


### PR DESCRIPTION
This adds an argument `-q` / `--quiet` for the ability to add [snapraid `--quiet` argument](https://www.snapraid.it/manual#6) to `scrub` and `sync` commands. this should also make it easier for others to add additional arguments to `snapraid_command`, such as those without values like the `--quiet` arg. This feature improves log output for scripted/cron execution.

I welcome feedback.