### PR TITLE
Added support for waiting for other processes

### DIFF
--- a/snapraid-runner.conf.example
+++ b/snapraid-runner.conf.example
@@ -8,6 +8,15 @@ deletethreshold = 40
 ; if you want touch to be ran each time
 touch = false
 
+[wait]
+enabled = false
+delay = 60
+maxdelays = 9
+
+[waitfiles]
+file-1 = wait-for.file
+file-2 = also-wait-for.file
+
 [logging]
 ; logfile to write to, leave empty to disable
 file = snapraid.log

--- a/snapraid-runner.py
+++ b/snapraid-runner.py
@@ -267,12 +267,12 @@ def run():
             wait_files.append(path)
         
         wait_delays = 0
-        while [f for f in wait_files if os.path.isfile(f)]:
+        while [path for key, path in config["waitfiles"].items() if os.path.isfile(path)]:
             if wait_delays > config["wait"]["maxdelays"]:
-                logging.error("Timed out waiting for other processes")
+                logging.error("Timed out waiting for {}".format(key))
                 finish(False);
             
-            logging.info("Waiting for other processes...")
+            logging.info("Waiting for {}...".format(key))
             
             time.sleep(config["wait"]["delay"])
             wait_delays += 1

--- a/snapraid-runner.py
+++ b/snapraid-runner.py
@@ -262,20 +262,23 @@ def run():
         finish(False)
 
     if config["wait"]["enabled"]:
-        wait_files = []
-        for key, path in config["waitfiles"].items():
-            wait_files.append(path)
-        
         wait_delays = 0
-        while [path for key, path in config["waitfiles"].items() if os.path.isfile(path)]:
-            if wait_delays > config["wait"]["maxdelays"]:
-                logging.error("Timed out waiting for {}".format(key))
-                finish(False);
-            
-            logging.info("Waiting for {}...".format(key))
-            
-            time.sleep(config["wait"]["delay"])
-            wait_delays += 1
+
+        while wait_delays <= config["wait"]["maxdelays"]:
+            wait = False
+            for key, path in config["waitfiles"].items():
+                if os.path.isfile(path):
+                    logging.info("Waiting for {}...".format(key))
+                    
+                    time.sleep(config["wait"]["delay"])
+                    wait_delays += 1
+                    wait = True
+                    break
+            if not wait:
+                break
+        else:
+            logging.error("Timed out waiting for {}".format(key))
+            finish(False);
 
     if config["snapraid"]["touch"]:
         logging.info("Running touch...")


### PR DESCRIPTION
Detect lock files from other processes that are/may be modifying the data disks and wait for them to be removed before continuing with the diff/sync.

I use StableBit Drivepool to pool my data disks, and have a landing zone to help prevent writes to the data disks while a sync is underway (and for protection against disk failure). This is configured to 'rebalance' onto the main data disks daily before the scheduled sync, with a file created to indicate that a balance is in progress - using the functionality added in this PR, I can get the script to pause until the balance has completed. As another example, it could also be used to wait for a long-running backup to complete.