### PR TITLE
Fixing broken log rotation

### DIFF
--- a/snapraid-runner.py
+++ b/snapraid-runner.py
@@ -180,7 +180,7 @@ def setup_logger():
     root_logger.addHandler(console_logger)
 
     if config["logging"]["file"]:
-        max_log_size = min(config["logging"]["maxsize"], 0) * 1024
+        max_log_size = max(config["logging"]["maxsize"], 0) * 1024
         file_logger = logging.handlers.RotatingFileHandler(
             config["logging"]["file"],
             maxBytes=max_log_size,


### PR DESCRIPTION
Fixes #32.

`min(config["logging"]["maxsize"], 0)` always returns 0. Passing `maxBytes=0` to `logging.handlers.RotatingFileHandler` means that we want to turn off Log rotation.

By replacing `min` by `max`, if maxisize is 0 or a negative value, log rotation will be disabled, while providing a positive value will set the maximum log size.