### PR TITLE
Add updated-files threshold limit for sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ It supports Windows, Linux and macOS and requires at least python3.7.
  `py -3 snapraid-runner.py` on Windows.
 
 ## Features
-* Runs `diff` before `sync` to see how many files were deleted and aborts if
-  that number exceeds a set threshold.
+* Runs `diff` before `sync` to see how many files were deleted or updated and aborts if
+  those numbers exceed set thresholds.
 * Can create a size-limited rotated logfile.
 * Can send notification emails after each run or only for failures.
 * Can run `scrub` after `sync`

--- a/snapraid-runner.conf.example
+++ b/snapraid-runner.conf.example
@@ -5,6 +5,8 @@ executable = snapraid
 config = snapraid.conf
 ; abort operation if there are more deletes than this, set to -1 to disable
 deletethreshold = 40
+; abort operation if there are more updates than this, set to -1 to disable
+updatethreshold = 100
 ; if you want touch to be ran each time
 touch = false
 

--- a/snapraid-runner.py
+++ b/snapraid-runner.py
@@ -147,7 +147,7 @@ def load_config(args):
             config[section][k] = v.strip()
 
     int_options = [
-        ("snapraid", "deletethreshold"), ("logging", "maxsize"),
+        ("snapraid", "deletethreshold"), ("snapraid", "updatethreshold"), ("logging", "maxsize"),
         ("scrub", "percentage"), ("scrub", "older-than"), ("email", "maxsize"),
     ]
     for section, option in int_options:
@@ -271,6 +271,13 @@ def run():
         logging.error(
             "Deleted files exceed delete threshold of {}, aborting".format(
                 config["snapraid"]["deletethreshold"]))
+        finish(False)
+
+    if (config["snapraid"]["updatethreshold"] >= 0 and
+            diff_results["update"] > config["snapraid"]["updatethreshold"]):
+        logging.error(
+            "Updated files exceed update threshold of {}, aborting".format(
+                config["snapraid"]["updatethreshold"]))
         finish(False)
 
     if (diff_results["remove"] + diff_results["add"] + diff_results["move"] +


### PR DESCRIPTION
Simple edit to add an updated-files threshold limit for sync, similar to the deleted-files threshold.