### PR TITLE
Updates to include Discord without additional deps, make smtp optional

### DIFF
--- a/snapraid-runner.conf.example
+++ b/snapraid-runner.conf.example
@@ -26,6 +26,7 @@ to =
 maxsize = 500
 
 [smtp]
+enabled = false
 host =
 ; leave empty for default port
 port =
@@ -40,3 +41,8 @@ password =
 enabled = false
 percentage = 12
 older-than = 10
+
+[discord]
+enabled = false
+; add webhook URL here
+webhook = 

--- a/snapraid-runner.py
+++ b/snapraid-runner.py
@@ -72,6 +72,44 @@ def snapraid_command(command, args={}, *, allow_statuscodes=[]):
         raise subprocess.CalledProcessError(ret, "snapraid " + command)
 
 
+def send_discord(success):
+    import json
+    import urllib.request
+
+    url = config['discord']['webhook']
+
+    if success:
+        body = "SnapRAID job completed successfully:\n"
+    else:
+        body = "Error during SnapRAID job:\n"
+
+    log = email_log.getvalue()
+
+    if len(log) > 2000:
+        log = log[:1800] + '--------- LOG WAS TOO BIG ----------'
+
+    body += f"```\n{log}\n```"
+
+    payload = {
+        'username': 'SnapRAID Runner',
+        'content': body
+    }
+
+    params = json.dumps(payload).encode('utf8')
+    headers = {
+        'content-type': 'application/json',
+        'user-agent': 'snapraid-runner/0.1'
+    }
+
+    try:
+        req = urllib.request.Request(url, method="POST",
+                                     headers=headers)
+        res = urllib.request.urlopen(req, data=params)
+        res.read().decode('utf8')
+    except Exception as e:
+        print(e)
+
+
 def send_email(success):
     import smtplib
     from email.mime.text import MIMEText
@@ -126,7 +164,11 @@ def send_email(success):
 def finish(is_success):
     if ("error", "success")[is_success] in config["email"]["sendon"]:
         try:
-            send_email(is_success)
+            if config['smtp']['enabled']:
+                send_email(is_success)
+
+            if config['discord']['enabled']:
+                send_discord(is_success)
         except Exception:
             logging.exception("Failed to send email")
     if is_success:
@@ -140,7 +182,7 @@ def load_config(args):
     global config
     parser = configparser.RawConfigParser()
     parser.read(args.conf)
-    sections = ["snapraid", "logging", "email", "smtp", "scrub"]
+    sections = ["snapraid", "logging", "email", "smtp", "scrub", "discord"]
     config = dict((x, defaultdict(lambda: "")) for x in sections)
     for section in parser.sections():
         for (k, v) in parser.items(section):
@@ -156,11 +198,15 @@ def load_config(args):
         except ValueError:
             config[section][option] = 0
 
+    config["smtp"]["enabled"] = (config["smtp"]["enabled"].lower() == "true")
     config["smtp"]["ssl"] = (config["smtp"]["ssl"].lower() == "true")
     config["smtp"]["tls"] = (config["smtp"]["tls"].lower() == "true")
     config["scrub"]["enabled"] = (config["scrub"]["enabled"].lower() == "true")
+    config["discord"]["enabled"] = (
+        config["discord"]["enabled"].lower() == "true")
     config["email"]["short"] = (config["email"]["short"].lower() == "true")
-    config["snapraid"]["touch"] = (config["snapraid"]["touch"].lower() == "true")
+    config["snapraid"]["touch"] = (
+        config["snapraid"]["touch"].lower() == "true")
 
     if args.scrub is not None:
         config["scrub"]["enabled"] = args.scrub


### PR DESCRIPTION
Added the ability to send discord messages via webhooks (no new dependencies were added). Configured using a new `[discord]` section in the config file (I updated the example file as well).

Also made smtp disableable using a new `enabled = false` flag in the `[smtp]` section since people may not want email at all, and it writes an `ERROR` log if you don't have the smtp host set up.