### PR TITLE
Enable parity spindown after update

### DIFF
--- a/snapraid-runner.conf.example
+++ b/snapraid-runner.conf.example
@@ -7,6 +7,8 @@ config = snapraid.conf
 deletethreshold = 40
 ; if you want touch to be ran each time
 touch = false
+; to spindown parity-disks after run (Linux/BSD only)
+spindown = true
 
 [logging]
 ; logfile to write to, leave empty to disable


### PR DESCRIPTION
After running snapraid sync/scrub, force the parity HDD to spindown (assuming the `spindown` configuration option is set).  My parity disks are on USB, and do not respond to `hdparm -S` (so I cannot configure automatic spindown) but they do respond to `hdparm -y` to force an immediate spindown.

This solution is Linux (Unix?) specific as it uses `sync`, `hdparm`, and `df` commands.  I am not aware of a portable way of implementing these options.