### PR TITLE
Exclude directories from diff threshold check

### DIFF
--- a/snapraid-runner.conf.example
+++ b/snapraid-runner.conf.example
@@ -42,3 +42,16 @@ enabled = false
 plan = 12
 ; minimum block age (in days) for scrubbing. Only used with percentage plans
 older-than = 10
+
+[exclude_diff]
+; set to true to fitler out paths from the diff command
+exclude = True
+; paths to exclude form diff threshold check.
+; paths =
+;   dir1/
+;   dir2/subdir/
+; or leave empty for none
+; paths =
+paths = 
+    backup/
+    test/

--- a/snapraid-runner.py
+++ b/snapraid-runner.py
@@ -271,7 +271,6 @@ def run():
         for line in diff_out:
             if line.split(" ")[0] != "remove" or not line.split(" ")[-1].startswith(tuple(config["exclude_diff"]["paths"])):
                 tmp_diff_out.append(line)
-                print(f"miss: {line}")
         diff_out = tmp_diff_out
 
     logging.info("*" * 60)

--- a/snapraid-runner.py
+++ b/snapraid-runner.py
@@ -16,6 +16,7 @@ from io import StringIO
 config = None
 email_log = None
 
+#Test
 
 def tee_log(infile, out_lines, log_level):
     """


### PR DESCRIPTION
Hi!
In my use case I use my storage as a backup target for configuration snapshots which rotate. This results in many files (correctly) being removed from old snapshots. The snapraid-runner detects these removals and stops execution since they exceed the defined threshold. 
Instead of abritrary increasing the threshold in order to avoid this, I implemented a filter which allows the user to define paths which should not be considered in the diff count for verifying the threshold. 