### PR TITLE
Use default config file in same directory

### DIFF
--- a/snapraid-runner.py
+++ b/snapraid-runner.py
@@ -200,9 +200,10 @@ def setup_logger():
 
 
 def main():
+    dir = os.path.dirname(os.path.realpath(__file__))
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--conf",
-                        default="snapraid-runner.conf",
+                        default=os.path.join(dir,"snapraid-runner.conf"),
                         metavar="CONFIG",
                         help="Configuration file (default: %(default)s)")
     parser.add_argument("--no-scrub", action='store_false',


### PR DESCRIPTION
When running from a cronjob, it couldn't find the default configuration file because of the different working directory. This change looks for the default config file in the same directory as the script, regardless of the current working directory.

Addresses #62